### PR TITLE
log key-value pairs

### DIFF
--- a/src/ndjson.rs
+++ b/src/ndjson.rs
@@ -1,6 +1,6 @@
 //! Print logs as ndjson.
 
-use log::{LevelFilter, Log, Metadata, Record};
+use log::{kv, LevelFilter, Log, Metadata, Record};
 use serde_json::Value;
 use std::collections::HashMap;
 use std::time;
@@ -49,7 +49,7 @@ impl Log for Logger {
 fn print_ndjson(record: &Record<'_>) {
     let msg = Msg {
         level: get_level(record.level()),
-        key_values: None,
+        key_values: format_kv_pairs(&record),
         time: time::UNIX_EPOCH.elapsed().unwrap().as_millis(),
         msg: record.args().to_string(),
     };
@@ -65,4 +65,29 @@ fn get_level(level: log::Level) -> u8 {
         Warn => 40,
         Error => 50,
     }
+}
+
+fn format_kv_pairs(record: &Record) -> Option<HashMap<String, Value>> {
+    struct Visitor {
+        key_values: Option<HashMap<String, Value>>,
+    }
+
+    impl<'kvs> kv::Visitor<'kvs> for Visitor {
+        fn visit_pair(
+            &mut self,
+            key: kv::Key<'kvs>,
+            val: kv::Value<'kvs>,
+        ) -> Result<(), kv::Error> {
+            if let None = self.key_values {
+                self.key_values = Some(HashMap::new());
+            }
+            let kv = self.key_values.as_mut().unwrap();
+            kv.insert(key.to_string(), val.to_string().into());
+            Ok(())
+        }
+    }
+
+    let mut visitor = Visitor { key_values: None };
+    record.key_values().visit(&mut visitor).unwrap();
+    visitor.key_values
 }


### PR DESCRIPTION
Adds logging of the experimental `log::kv` key-value pairs. Thanks!

ref https://github.com/rust-lang-nursery/log/issues/328