### PR TITLE
use serde_json for string output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,8 +63,9 @@ dependencies = [
  "js-sys 0.3.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "kv-log-macro 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "web-sys 0.3.25 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -158,7 +159,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "1.0.97"
+version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -173,12 +174,12 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.40"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -227,8 +228,8 @@ name = "wasm-bindgen"
 version = "0.2.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-macro 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -328,9 +329,9 @@ dependencies = [
 "checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
 "checksum rustc-demangle 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "a7f4dccf6f4891ebcc0c39f9b6eb1a83b9bf5d747cb439ec6fba4f3b977038af"
 "checksum ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c92464b447c0ee8c4fb3824ecc8383b81717b9f1e74ba2e72540aef7b9f82997"
-"checksum serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)" = "d46b3dfedb19360a74316866cef04687cd4d6a70df8e6a506c63512790769b72"
+"checksum serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)" = "5317f7588f0a5078ee60ef675ef96735a1442132dc645eb1d12c018620ed8cd3"
 "checksum serde_derive 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)" = "c22a0820adfe2f257b098714323563dd06426502abbbce4f51b72ef544c5027f"
-"checksum serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)" = "051c49229f282f7c6f3813f8286cc1e3323e8051823fce42c7ea80fe13521704"
+"checksum serde_json 1.0.56 (registry+https://github.com/rust-lang/crates.io-index)" = "3433e879a558dde8b5e8feb2a04899cf34fdde1fafb894687e52105fc1162ac3"
 "checksum sourcefile 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf77cb82ba8453b42b6ae1d692e4cdc92f9a47beaf89a847c8be83f4e328ad3"
 "checksum syn 0.15.39 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d960b829a55e56db167e861ddb43602c003c7be0bee1d345021703fac2fb7c"
 "checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ edition = "2018"
 log = { version = "0.4.7", features = ["kv_unstable", "std"] }
 serde = "1.0.97"
 serde_derive = "1.0.97"
+serde_json = "1.0.56"
 cfg-if = "0.1.9"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/examples/log.rs
+++ b/examples/log.rs
@@ -8,4 +8,6 @@ fn main() {
     log::info!("Request handled", { method: "GET", path: "/foo/bar", status: 200, elapsed: "4ms" });
     log::debug!("Getting String as bson value type");
     log::trace!("Task spawned", {task_id: "567", thread_id: "12"});
+    log::info!(r#"raw " fun with JSON"#);
+    log::info!("n\ne\nw\nl\ni\nn\ne\n");
 }

--- a/src/ndjson.rs
+++ b/src/ndjson.rs
@@ -23,14 +23,12 @@ impl Log for Logger {
         if self.enabled(record.metadata()) {
             let stdout = io::stdout();
             let mut handle = stdout.lock();
-            write!(&mut handle, "{}", '{').unwrap();
-            write!(&mut handle, "\"level\":{}", get_level(record.level())).unwrap();
-            let now = time::UNIX_EPOCH.elapsed().unwrap().as_millis();
-            write!(&mut handle, ",\"time\":{}", now).unwrap();
-            write!(&mut handle, ",\"msg\":").unwrap();
+            let level = get_level(record.level());
+            let time = time::UNIX_EPOCH.elapsed().unwrap().as_millis();
+            write!(&mut handle, "{{\"level\":{},\"time\":{},\"msg\":", level, time).unwrap();
             serde_json::to_writer(&mut handle, record.args()).unwrap();
             format_kv_pairs(&mut handle, &record);
-            writeln!(&mut handle, "{}", "}").unwrap();
+            writeln!(&mut handle, "}}").unwrap();
         }
     }
     fn flush(&self) {}

--- a/src/ndjson.rs
+++ b/src/ndjson.rs
@@ -27,7 +27,8 @@ impl Log for Logger {
             write!(&mut handle, "\"level\":{}", get_level(record.level())).unwrap();
             let now = time::UNIX_EPOCH.elapsed().unwrap().as_millis();
             write!(&mut handle, ",\"time\":{}", now).unwrap();
-            write!(&mut handle, ",\"msg\":\"{}\"", record.args()).unwrap();
+            write!(&mut handle, r#","msg":"#).unwrap();
+            serde_json::to_writer(&mut handle, record.args()).unwrap();
             format_kv_pairs(&mut handle, &record);
             writeln!(&mut handle, "{}", "}").unwrap();
         }

--- a/src/ndjson.rs
+++ b/src/ndjson.rs
@@ -27,7 +27,7 @@ impl Log for Logger {
             write!(&mut handle, "\"level\":{}", get_level(record.level())).unwrap();
             let now = time::UNIX_EPOCH.elapsed().unwrap().as_millis();
             write!(&mut handle, ",\"time\":{}", now).unwrap();
-            write!(&mut handle, r#","msg":"#).unwrap();
+            write!(&mut handle, ",\"msg\":").unwrap();
             serde_json::to_writer(&mut handle, record.args()).unwrap();
             format_kv_pairs(&mut handle, &record);
             writeln!(&mut handle, "{}", "}").unwrap();


### PR DESCRIPTION
previously, if you logged things with quotes or newlines, the output would be incorrect JSON:
```
{"level":30,"time":1594912068454,"msg":"raw " fun with JSON"}
{"level":30,"time":1594912068454,"msg":"n
e
w
l
i
n
e
"}
```

now, it is escaped:
```
{"level":30,"time":1594912085549,"msg":"raw \" fun with JSON"}
{"level":30,"time":1594912085549,"msg":"n\ne\nw\nl\ni\nn\ne\n"}
```

this unscientific measurement went from about 550ms (before) to about 590-600ms (after):
```
cargo build --release --example million
hyperfine ./target/release/examples/million
```
so that's almost a 10% performance hit for logs that don't include anything that needs to be escaped.