### PR TITLE
refactor: use Try operator in kv::Visitor

### DIFF
--- a/src/ndjson.rs
+++ b/src/ndjson.rs
@@ -56,7 +56,7 @@ fn format_kv_pairs<'b>(mut out: &mut StdoutLock<'b>, record: &Record) {
             key: kv::Key<'kvs>,
             val: kv::Value<'kvs>,
         ) -> Result<(), kv::Error> {
-            write!(self.string, ",\"{}\":{}", key, val).unwrap();
+            write!(self.string, ",\"{}\":{}", key, val)?;
             Ok(())
         }
     }

--- a/src/pretty.rs
+++ b/src/pretty.rs
@@ -49,7 +49,7 @@ fn format_kv_pairs<'b>(mut out: &mut StdoutLock<'b>, record: &Record) {
             key: kv::Key<'kvs>,
             val: kv::Value<'kvs>,
         ) -> Result<(), kv::Error> {
-            write!(self.stdout, "\n    {}{}{} {}", BOLD, key, RESET, val).unwrap();
+            write!(self.stdout, "\n    {}{}{} {}", BOLD, key, RESET, val)?;
             Ok(())
         }
     }

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -66,7 +66,7 @@ fn format_kv_pairs(record: &Record) -> Option<Object> {
             if self.hashmap.is_none() {
                 self.hashmap = Some(HashMap::new())
             }
-            let hm = self.hashmap.as_mut().unwrap();
+            let hm = self.hashmap.as_mut()?;
             hm.insert(key.to_string(), val.to_string());
             Ok(())
         }


### PR DESCRIPTION
Avoids unwrapping in functions which return a `Result`.

Admittedly this is limitedly useful here because everything is preseently unwrapped at a higher-level anyways but is still good practice.