### PR TITLE
fix: corrected ndjson key-value formatting

### DIFF
--- a/src/ndjson.rs
+++ b/src/ndjson.rs
@@ -56,7 +56,7 @@ fn format_kv_pairs<'b>(mut out: &mut StdoutLock<'b>, record: &Record) {
             key: kv::Key<'kvs>,
             val: kv::Value<'kvs>,
         ) -> Result<(), kv::Error> {
-            write!(self.string, ",\"{}\":{}", key, val).unwrap();
+            write!(self.string, ",\"{}\":\"{}\"", key, val).unwrap();
             Ok(())
         }
     }


### PR DESCRIPTION
https://github.com/rust-lang/log/pull/400
was merged upstream and caused this crate's json key-value logging to break.

This is problem for Tide, which uses key-value logging in it's default log middleware.

Fixes: https://github.com/lrlna/femme/issues/17
Refs: https://github.com/http-rs/tide/issues/752