### PR TITLE
Add clarification to docs that it doesn't use RUST_LOG

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,9 @@ mod wasm;
 
 /// Starts logging depending on current environment.
 ///
+/// Always logs with a LevelFilter of Info.
+/// For other filters use with_level.
+///
 /// # Log output
 ///
 /// - when compiling with `--release` uses ndjson.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ mod wasm;
 
 /// Starts logging depending on current environment.
 ///
-/// Always logs with a LevelFilter of Info.
+/// Always logs with 'Info' LevelFilter.
 /// For other filters use with_level.
 ///
 /// # Log output


### PR DESCRIPTION
I got quite confused by the documentation of `start` as it says "depending on current environment" which I read to mean it used the env `RUST_LOG` variable to set its log level.

I have added a couple of lines to the documentation to help clarify this so people don't make the same mistake I did.