### PR TITLE
chore: build wasm as part of CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,14 @@ workflows:
             parameters:
               platform: [linux]
               rust_channel: [stable]
+  wasm:
+    jobs:
+      - wasm:
+          name: Wasm compilation
+          matrix:
+            parameters:
+              platform: [linux]
+              rust_channel: [stable]
   test:
     jobs:
       - test:
@@ -70,6 +78,24 @@ jobs:
       - run:
           name: Run cargo clippy
           command: cargo clippy --all-targets --all-features -- -D warnings && cargo clippy --benches
+
+  lint:
+    parameters:
+      rust_channel:
+        type: enum
+        enum: ["stable", "nightly"]
+        default: stable
+      platform:
+        type: executor
+    executor: << parameters.platform >>
+    steps:
+      - checkout
+      - install_system_deps:
+          rust_channel: << parameters.rust_channel >>
+          platform: << parameters.platform >>
+      - run:
+          name: cargo build on wasm32-unknown-unknown
+          command: cargo build --target wasm32-unknown-unknown
 
   test:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,11 +79,11 @@ jobs:
           name: Run cargo clippy
           command: cargo clippy --all-targets --all-features -- -D warnings && cargo clippy --benches
 
-  lint:
+  wasm:
     parameters:
       rust_channel:
         type: enum
-        enum: ["stable", "nightly"]
+        enum: ["stable"]
         default: stable
       platform:
         type: executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,10 @@ jobs:
           rust_channel: << parameters.rust_channel >>
           platform: << parameters.platform >>
       - run:
-          name: cargo build on wasm32-unknown-unknown
+          name: Download wasm target
+          command: rustup target add wasm32-unknown-unknown
+      - run:
+          name: Run cargo build on wasm32-unknown-unknown
           command: cargo build --target wasm32-unknown-unknown
 
   test:


### PR DESCRIPTION
To ensure femme can run on wasm, run `cargo build --target wasm32-unknown-unknown` job in one of the workflows.

This should prevent accidental failures like with #40. Should merge this after #39 