### PR TITLE
adds a builder interface to init the logger

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,16 +51,70 @@ pub fn start() {
 /// femme::with_level(log::LevelFilter::Trace);
 /// ```
 pub fn with_level(level: log::LevelFilter) {
-    #[cfg(target_arch = "wasm32")]
-    wasm::start(level);
+    Femme::builder().level(level).into_femme().start()
+}
 
-    #[cfg(not(target_arch = "wasm32"))]
-    {
-        // Use ndjson in release mode, pretty logging while debugging.
-        if cfg!(debug_assertions) {
-            pretty::start(level);
-        } else {
-            ndjson::start(level);
+#[derive(Debug)]
+pub struct Femme {
+    level: LevelFilter,
+    mode: Option<Mode>,
+}
+
+#[derive(Debug)]
+enum Mode {
+    Pretty,
+    NdJson,
+}
+
+#[derive(Debug)]
+pub struct FemmeBuilder {
+    level: Option<LevelFilter>,
+    mode: Option<Mode>,
+}
+
+impl Femme {
+    pub fn builder() -> FemmeBuilder {
+        FemmeBuilder {
+            level: None,
+            mode: None,
+        }
+    }
+    pub fn start(self) {
+        #[cfg(target_arch = "wasm32")]
+        wasm::start(self.level);
+        #[cfg(not(target_arch = "wasm32"))]
+        match self.mode {
+            Some(Mode::Pretty) => pretty::start(self.level),
+            Some(Mode::NdJson) => ndjson::start(self.level),
+            None => {
+                // By default, use ndjson in release mode, pretty logging while debugging.
+                if cfg!(debug_assertions) {
+                    pretty::start(self.level);
+                } else {
+                    ndjson::start(self.level);
+                }
+            }
+        }
+    }
+}
+
+impl FemmeBuilder {
+    pub fn level(mut self, level: LevelFilter) -> FemmeBuilder {
+        self.level = Some(level);
+        self
+    }
+    pub fn pretty(mut self) -> FemmeBuilder {
+        self.mode = Some(Mode::Pretty);
+        self
+    }
+    pub fn ndjson(mut self) -> FemmeBuilder {
+        self.mode = Some(Mode::NdJson);
+        self
+    }
+    pub fn into_femme(self) -> Femme {
+        Femme {
+            level: self.level.unwrap_or(LevelFilter::Info),
+            mode: self.mode,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,13 @@ pub fn with_level(level: log::LevelFilter) {
     Femme::builder().level(level).into_femme().start()
 }
 
+/// ```
+/// femme::Femme::builder()
+///    .ndjson()
+///    .level(log::LevelFilter::Trace)
+///    .into_femme()
+///    .start();
+/// ```
 #[derive(Debug)]
 pub struct Femme {
     level: LevelFilter,


### PR DESCRIPTION
This should allow the user to set their preferred logging format regardless of compilation mode. And allow the library to add more knobs in the future in a (hopefully) backward compatible way.

```rust
femme::Femme::builder()
    .ndjson()
    .level(log::LevelFilter::Trace)
    .into_femme()
    .start();
```


Let me know if this PR has any interest to you, I'll be adding documentation shortly then.